### PR TITLE
Also require BMI1 and LZCNT instructions

### DIFF
--- a/docs/validator/hardware.md
+++ b/docs/validator/hardware.md
@@ -14,14 +14,14 @@ This page covers the minimum and recommended hardware requirements for engaging 
 | Hardware       |  Recommended Specifications                                                  |
 | -------------- | ---------------------------------------------------------------              |
 | CPU            | x86_64 (Intel, AMD) processor with at least 8 physical cores                 |
-| CPU Features   | CMPXCHG16B, POPCNT, SSE4.1, SSE4.2, AVX                                      |
+| CPU Features   | CMPXCHG16B, POPCNT, SSE4.1, SSE4.2, AVX, BMI1, LZCNT                         |
 | RAM            | 24GB DDR4                                                                    |
 | Storage        | 1TB SSD (NVMe SSD is recommended. HDD will be enough for localnet only)      |
 
 Verify CPU feature support by running the following command on Linux:
 
 ```
-lscpu | grep -P '(?=.*avx )(?=.*sse4.2 )(?=.*cx16 )(?=.*popcnt )' > /dev/null \
+lscpu | grep -P '(?=.*avx )(?=.*sse4.2 )(?=.*cx16 )(?=.*popcnt )(?=.*bmi1 )(?=.*abm )' > /dev/null \
   && echo "Supported" \
   || echo "Not supported"
 ```
@@ -31,14 +31,14 @@ lscpu | grep -P '(?=.*avx )(?=.*sse4.2 )(?=.*cx16 )(?=.*popcnt )' > /dev/null \
 | Hardware       |  Minimal Specifications                                                     |
 | -------------- | ---------------------------------------------------------------             |
 | CPU            | x86_64 (Intel, AMD) processor with at least 8 physical cores                |
-| CPU Features   | CMPXCHG16B, POPCNT, SSE4.1, SSE4.2, AVX                                     |
-| RAM            | 16GB DDR4                                                                    |
+| CPU Features   | CMPXCHG16B, POPCNT, SSE4.1, SSE4.2, AVX, BMI1, LZCNT                        |
+| RAM            | 16GB DDR4                                                                   |
 | Storage        | 500GB SSD (NVMe SSD is recommended. HDD will be enough for localnet only)   |
 
 Verify CPU feature support by running the following command on Linux:
 
 ```
-lscpu | grep -P '(?=.*avx )(?=.*sse4.2 )(?=.*cx16 )(?=.*popcnt )' > /dev/null \
+lscpu | grep -P '(?=.*avx )(?=.*sse4.2 )(?=.*cx16 )(?=.*popcnt )(?=.*bmi1 )(?=.*abm )' > /dev/null \
   && echo "Supported" \
   || echo "Not supported"
 ```


### PR DESCRIPTION
Note: the intel manual calls this CPUID bit LZCNT, but linux calls it ABM. Following the intel manual in the CPU feature table.