### PR TITLE
Update build instructions

### DIFF
--- a/docs/rpc/run-rpc-node-without-nearup.md
+++ b/docs/rpc/run-rpc-node-without-nearup.md
@@ -83,11 +83,10 @@ takes approximately 25 minutes). Note that compilation will need over
 with processes being killed, you might want to try reducing number of
 parallel jobs, for example: `CARGO_BUILD_JOBS=8 make release`.
 
-By the way, if you’re familiar with Cargo, you could wonder why not
-run `cargo build -p neard --release` instead.  While this will produce
-a binary, the result will be a less optimized version.  On technical
-level, this is because building via `make neard` enables link-time
-optimisation which is disabled by default.
+If you’re familiar with Cargo, you could also run `cargo build -p neard
+--release` instead, which might or might not be equivalent to `make release`. It
+is equivalent at the time of writing, but we don't guarantee this. If in doubt,
+consult the `Makefile`, or just stick with `make release`.
 
 The binary path is `target/release/neard`
 
@@ -181,11 +180,10 @@ takes approximately 25 minutes). Note that compilation will need over
 with processes being killed, you might want to try reducing number of
 parallel jobs, for example: `CARGO_BUILD_JOBS=8 make release`.
 
-By the way, if you’re familiar with Cargo, you could wonder why not
-run `cargo build -p neard --release` instead.  While this will produce
-a binary, the result will be a less optimized version.  On technical
-level, this is because building via `make neard` enables link-time
-optimisation which is disabled by default.
+If you’re familiar with Cargo, you could also run `cargo build -p neard
+--release` instead, which might or might not be equivalent to `make release`. It
+is equivalent at the time of writing, but we don't guarantee this. If in doubt,
+consult the `Makefile`, or just stick with `make release`.
 
 The binary path is `target/release/neard`
 


### PR DESCRIPTION
Also make them a bit more future-proof, so that updating is not strictly required.

Should we just cut the section? I don't think so: it's ok if people bypass the Makefile, as long as they know what they are doing and not complain if we break an unsupported workflow.

counterpart to https://github.com/near/nearcore/pull/7923