### PR TITLE
Update snapshots.md

### DIFF
--- a/docs/intro/snapshots.md
+++ b/docs/intro/snapshots.md
@@ -35,7 +35,7 @@ $ chain="mainnet"  # or "testnet"
 $ kind="rpc"       # or "archive"
 $ aws s3 --no-sign-request cp "s3://near-protocol-public/backups/${chain:?}/${kind:?}/latest" .
 $ latest=$(cat latest)
-$ aws s3 --no-sign-request cp --no-sign-request --recursive "s3://near-protocol-public/backups/${chain:?}/${kind:?}/${latest:?}" ~/.near/data
+$ aws s3 sync --no-sign-request "s3://near-protocol-public/backups/${chain:?}/${kind:?}/${latest:?}" ~/.near/data
 ```
 
 For a faster snapshot download speed, use s5cmd, the download accelerator for S3 written in Go. For download instruction, please see https://github.com/peak/s5cmd.


### PR DESCRIPTION
I suggest replacing the copy command with the sync command. In the case of a copy error, the previous command starts the copy from the beginning. I offer to change the command on this context:
`aws s3 sync --no-sign-request  "s3://near-protocol-public/backups/${chain:?}/${kind:?}/${latest:?}" ~/.near/data`