### PR TITLE
Update snapshots.md

### DIFF
--- a/docs/intro/snapshots.md
+++ b/docs/intro/snapshots.md
@@ -6,10 +6,63 @@ sidebar_position: 3
 description: Node Data Snapshots
 ---
 
+**Notice: The AWS S3 endpoints will be inaccessible starting January 1st, 2024. Please use the updated Cloudfront endpoints for snapshot downloads to ensure uninterrupted service.**
 
-Before you start running a node, you must first sync with the network. This means your node needs to download all the headers and blocks that other nodes in the network already have. You can speed up this process by downloading the latest data snapshots from a public S3 bucket.
+Before you start running a node, you must first sync with the network. This means your node needs to download all the headers and blocks that other nodes in the network already have. You can speed up this process by downloading the latest data snapshots from a public cloudfront endpoint.
 
 Here are the available snapshots directories based on node type and network. Please note that the snapshots are updated every 12 hours.
+
+
+| Node Type and Network| S3 Path                                                                  |
+| -------------------- | ------------------------------------------------------------------------ |
+| RPC testnet          | https://dcf58hz8pnro2.cloudfront.net/backups/testnet/rpc/latest          |
+| RPC mainnet          | https://dcf58hz8pnro2.cloudfront.net/backups/mainnet/rpc/latest          |
+| Archival testnet     | https://dcf58hz8pnro2.cloudfront.net/backups/testnet/archive/latest      |
+| Archival mainnet     | https://dcf58hz8pnro2.cloudfront.net/backups/mainnet/archive/latest      |
+
+----
+Prerequisite:
+
+Recommended download client [`rclone`](https://rclone.org). 
+This tool is present in many Linux distributions. There is also a version for Windows.
+And its main merit is multithread.
+You can [read about it on](https://rclone.org)
+
+First, install rclone:
+```
+$ sudo apt install rclone
+```
+Next, prepare config, so you don't need to specify all the parameters interactively:
+```
+mkdir -p ~/.config/rclone
+touch ~/.config/rclone/rclone.conf
+```
+
+, and paste the following config into `rclone.conf`:
+```
+[near_cf]
+type = s3
+provider = AWS
+download_url = https://dcf58hz8pnro2.cloudfront.net/
+acl = public-read
+server_side_encryption = AES256
+region = ca-central-1
+
+```
+Commands to run:
+```
+chain="mainnet"  # or "testnet"
+kind="rpc"       # or "archive"
+rclone copy --no-check-certificate near_s3://near-protocol-public/backups/${chain:?}/${kind:?}/latest ./
+latest=$(cat latest)
+rclone copy --no-check-certificate --progress --transfers=6 \
+  near_cf://near-protocol-public/backups/${chain:?}/${kind:?}/${latest:?} ~/.near/data
+```
+
+----
+
+
+**Notice: The following section are the older instructions to download snapshots from s3. Direct s3 access will be deprecated starting January 1, 2024.**
 
 
 | Node Type and Network| S3 Path                                                       |
@@ -21,6 +74,7 @@ Here are the available snapshots directories based on node type and network. Ple
 
 
 ----
+
 
 If you've [initialized the working directory for your node](/validator/compile-and-run-a-node#3-initialize-working-directory-1) without passing in a preferred location, the default working directory for your node is `~/.near`. It is recommended that you wget and untar into a `data` folder under `~/.near/`. The new `~/.near/data` is where your node will store historical states and write its state. To use the default location, run the following commands.
 


### PR DESCRIPTION
We have added an AWS Cloudfront endpoint for snapshot downloads to utilize AWS cloudfront edge network to help increase download speeds and while reducing cost. Updating the  snapshot doc to reflect the recommend Cloudfront endpoint.