### PR TITLE
doc: near proposal is deprecated command

### DIFF
--- a/docs/validator/validator-bootcamp.md
+++ b/docs/validator/validator-bootcamp.md
@@ -135,7 +135,7 @@ A proposal by a validator indicates they would like to enter the validator set, 
 
 Command:
 ```
-near proposals
+near validators proposals
 ```
 
 ##### Validators Current


### PR DESCRIPTION
i tried validator bootcamp step by step.

in "Validator Stats" Section, i had a command error.

"near proposals" is deprecated.

<img width="899" alt="image" src="https://github.com/user-attachments/assets/28d0b5d3-2b60-45dd-b3c7-41d8c7e24afb" />

"near validators proposals" is working.

it's change will be valuable for unfamiliar with near validator node operator.

<img width="815" alt="image" src="https://github.com/user-attachments/assets/243adbec-4a08-49a8-88b4-35a279d37c12" />
