### PR TITLE
Remove mentions of betanet from the docs

### DIFF
--- a/docs/intro/keys.md
+++ b/docs/intro/keys.md
@@ -60,10 +60,6 @@ For concrete examples of keys being used as identifiers, you can see a list of v
   - `https://rpc.testnet.near.org/status`
   - `https://rpc.testnet.near.org/network_info`
 
-- NEAR betanet
-  - `https://rpc.betanet.near.org/status`
-  - `https://rpc.betanet.near.org/network_info`
-
 >Got a question?
 <a href="https://stackoverflow.com/questions/tagged/nearprotocol">
   <h8>Ask it on StackOverflow!</h8></a>

--- a/docs/intro/what-is-a-node.md
+++ b/docs/intro/what-is-a-node.md
@@ -19,7 +19,7 @@ You may decide to run a node of your own for a few reasons:
 - To develop and deploy contracts on a local (independent and isolated) node (sometimes called "localnet"). (†)
 - To quickly extract blockchain data that can be used for chain analytics, block explorer, etc.
 
-_( † ) `localnet` would be the right choice if you prefer to avoid leaking information about your work during the development process since `testnet` and `betanet` are *public* networks. `localnet` also gives you total control over accounts, economics and other factors for more advanced use cases (ie. making changes to `nearcore`)._
+_( † ) `localnet` would be the right choice if you prefer to avoid leaking information about your work during the development process since `testnet` is a *public* network. `localnet` also gives you total control over accounts, economics and other factors for more advanced use cases (ie. making changes to `nearcore`)._
 
 
 ## Types of Network {#types-of-network}
@@ -28,7 +28,6 @@ There are a few different networks to potentially run a node. Each network opera
 
 * [`mainnet`](https://docs.near.org/concepts/basics/networks#mainnet)
 * [`testnet`](https://docs.near.org/concepts/basics/networks#testnet)
-* [`betanet`](https://docs.near.org/concepts/basics/networks#betanet)
 * [`localnet`](https://docs.near.org/concepts/basics/networks#localnet)
 
 

--- a/docs/maintenance/node-maintenance.md
+++ b/docs/maintenance/node-maintenance.md
@@ -28,13 +28,6 @@ Typically, `testnet` and `mainnet` releases are five weeks apart to allow nearco
 - `testnet` Wednesday at 15:00 UTC. The release tag is mapped with `x.y.z-rc.1`
 - `mainnet` Wednesday at 15:00 UTC. The release tag is mapped with `x.y.z`
 
-<blockquote class="warning">
-<strong>Heads up</strong><br /><br />
-
-`betanet` provides cutting-edge testing grounds for validators, with daily updates and frequent hard-forks. For more information on nodes that are running on `betanet`, please see the [betanet analysis group on the governance forum](https://gov.near.org/t/betanet-analysis-group-reports/339).
-</blockquote>
-
-
 ## Nearcore Emergency Updates {#nearcore-emergency-updates}
 
 We may issue a `[CODE_YELLOW_TESTNET]` or `[CODE_YELLOW_MAINNET]` if the network is suffering minor issues, or a new software release introduces incompatibilities and requires additional testing.
@@ -56,7 +49,7 @@ The tags we propose are as follows:
 
 `[CODE_GREEN_<network_id>]` where `<network_id>` is either `MAINNET` or `TESTNET`. This usually means some general announcement that is more informational or doesn’t require actions within a short period of time. It could be an announcement of a release that improves performance or a fix some minor issues.
 
-Call-to-actions for technical teams if the network is stalling and there's the need to coordinate a manual node restart. Such messages begin with `[CODE_RED_BETANET]` or `[CODE_RED_TESTNET]`, and will be posted in the read-only Validator Announcement channel on [Discord](https://discord.gg/xsrHaCb). The same message may be repeated in other channels, to have higher outreach.
+Call-to-actions for technical teams if the network is stalling and there's the need to coordinate a manual node restart. Such messages begin with `[CODE_RED_MAINNET]` or `[CODE_RED_TESTNET]`, and will be posted in the read-only Validator Announcement channel on [Discord](https://discord.gg/xsrHaCb). The same message may be repeated in other channels, to have higher outreach.
 
 
 >Got a question?

--- a/website/mlc_config.json
+++ b/website/mlc_config.json
@@ -5,9 +5,6 @@
     },
     {
       "pattern": "^https://twitter.com"
-    },
-    {
-      "pattern": "^https://rpc.betanet.near.org"
     }
   ],
   "replacementPatterns": [


### PR DESCRIPTION
Remove all mentions of `betanet`, it's no longer active.