### PR TITLE
Update hardware-validator.md

### DIFF
--- a/docs/validator/hardware-validator.md
+++ b/docs/validator/hardware-validator.md
@@ -60,6 +60,10 @@ Estimated monthly costs depending on cloud provider:
 | GCP            | n2-standard-8    | $280 CPU + $240 storage |
 | Azure          | Standard_D8s_v5  | $180 CPU + $200 storage |
 
+| Bare Metal     | CPU              | Linux                   |
+| -------------- |------------------|-------------------------|
+| CherryServers  | Ryzen 7700       | $265 CPU + storage      | 
+
 # Testnet
 
 ## Recommended Hardware Specifications {#recommended-hardware-specifications}
@@ -111,6 +115,10 @@ Estimated monthly costs depending on cloud provider:
 | AWS            | m5a.2xlarge      | $160 CPU + $80 storage  |
 | GCP            | n2-standard-8    | $280 CPU + $120 storage |
 | Azure          | Standard_D8s_v5  | $180 CPU + $100 storage |
+
+| Bare Metal     | CPU              | Linux                   |
+| -------------- |------------------|-------------------------|
+| CherryServers  | Ryzen 7700       | $226 CPU + storage      | 
 
 <blockquote class="info">
 <strong>Resources for Cost Estimation</strong><br /><br />


### PR DESCRIPTION
Added a bare metal option, as it might be worth considering alongside all the hyperscalers.  Bare metal not only provides better performance but is also usually more cost-effective.