### PR TITLE
doc(docs): remove outdated cargo build notes

### DIFF
--- a/docs/archival/run-archival-node.md
+++ b/docs/archival/run-archival-node.md
@@ -84,12 +84,6 @@ takes approximately 25 minutes). Note that compilation will need over
 with processes being killed, you might want to try reducing number of
 parallel jobs, for example: `CARGO_BUILD_JOBS=8 make release`.
 
-By the way, if you’re familiar with Cargo, you could wonder why not
-run `cargo build -p neard --release` instead.  While this will produce
-a binary, the result will be a less optimized version.  On technical
-level, this is because building via `make neard` enables link-time
-optimisation which is disabled by default.
-
 The binary path is `target/release/neard`
 
 ### 3. Initialize working directory {#3-initialize-working-directory}
@@ -177,12 +171,6 @@ takes approximately 25 minutes). Note that compilation will need over
 1 GB of memory per virtual core the machine has. If the build fails
 with processes being killed, you might want to try reducing number of
 parallel jobs, for example: `CARGO_BUILD_JOBS=8 make release`.
-
-By the way, if you’re familiar with Cargo, you could wonder why not
-run `cargo build -p neard --release` instead.  While this will produce
-a binary, the result will be a less optimized version.  On technical
-level, this is because building via `make neard` enables link-time
-optimisation which is disabled by default.
 
 The binary path is `target/release/neard`
 

--- a/docs/rpc/run-rpc-node.md
+++ b/docs/rpc/run-rpc-node.md
@@ -83,11 +83,6 @@ takes approximately 25 minutes). Note that compilation will need over
 with processes being killed, you might want to try reducing number of
 parallel jobs, for example: `CARGO_BUILD_JOBS=8 make release`.
 
-If you’re familiar with Cargo, you could also run `cargo build -p neard
---release` instead, which might or might not be equivalent to `make release`. It
-is equivalent at the time of writing, but we don't guarantee this. If in doubt,
-consult the `Makefile`, or just stick with `make release`.
-
 The binary path is `target/release/neard`
 
 ### 3. Initialize working directory {#3-initialize-working-directory}
@@ -170,11 +165,6 @@ takes approximately 25 minutes). Note that compilation will need over
 1 GB of memory per virtual core the machine has. If the build fails
 with processes being killed, you might want to try reducing number of
 parallel jobs, for example: `CARGO_BUILD_JOBS=8 make release`.
-
-If you’re familiar with Cargo, you could also run `cargo build -p neard
---release` instead, which might or might not be equivalent to `make release`. It
-is equivalent at the time of writing, but we don't guarantee this. If in doubt,
-consult the `Makefile`, or just stick with `make release`.
 
 The binary path is `target/release/neard`
 

--- a/docs/validator/compile-and-run-a-node.md
+++ b/docs/validator/compile-and-run-a-node.md
@@ -106,12 +106,6 @@ takes approximately 25 minutes). Note that compilation will need over
 with processes being killed, you might want to try reducing number of
 parallel jobs, for example: `CARGO_BUILD_JOBS=8 make neard`.
 
-By the way, if you’re familiar with Cargo, you could wonder why not
-run `cargo build -p neard --release` instead.  While this will produce
-a binary, the result will be a less optimized version.  On technical
-level, this is because building via `make neard` enables link-time
-optimisation which is disabled by default. The binary path is `target/release/neard`.
-
 
 For `localnet`, you also have the option to build in nightly mode (which is experimental and is used for cutting-edge testing). When you compile, use the following command:
 ```bash
@@ -179,12 +173,6 @@ takes approximately 25 minutes). Note that compilation will need over
 1 GB of memory per virtual core the machine has. If the build fails
 with processes being killed, you might want to try reducing number of
 parallel jobs, for example: `CARGO_BUILD_JOBS=8 make neard`.
-
-By the way, if you’re familiar with Cargo, you could wonder why not
-run `cargo build -p neard --release` instead.  While this will produce
-a binary, the result will be a less optimized version.  On technical
-level, this is because building via `make neard` enables link-time
-optimisation which is disabled by default.
 
 The binary path is `target/release/neard`
 
@@ -414,12 +402,6 @@ takes approximately 25 minutes). Note that compilation will need over
 1 GB of memory per virtual core the machine has. If the build fails
 with processes being killed, you might want to try reducing number of
 parallel jobs, for example: `CARGO_BUILD_JOBS=8 make neard`.
-
-By the way, if you’re familiar with Cargo, you could wonder why not
-run `cargo build -p neard --release` instead.  While this will produce
-a binary, the result will be a less optimized version.  On technical
-level, this is because building via `make neard` enables link-time
-optimisation which is disabled by default.
 
 The binary path is `target/release/neard`
 

--- a/docs/validator/compile-and-run-a-node.md
+++ b/docs/validator/compile-and-run-a-node.md
@@ -106,6 +106,7 @@ takes approximately 25 minutes). Note that compilation will need over
 with processes being killed, you might want to try reducing number of
 parallel jobs, for example: `CARGO_BUILD_JOBS=8 make neard`.
 
+The binary path is `target/release/neard`.
 
 For `localnet`, you also have the option to build in nightly mode (which is experimental and is used for cutting-edge testing). When you compile, use the following command:
 ```bash

--- a/docs/validator/compile-and-run-a-node.md
+++ b/docs/validator/compile-and-run-a-node.md
@@ -106,7 +106,7 @@ takes approximately 25 minutes). Note that compilation will need over
 with processes being killed, you might want to try reducing number of
 parallel jobs, for example: `CARGO_BUILD_JOBS=8 make neard`.
 
-The binary path is `target/release/neard`.
+The binary path is `target/release/neard`
 
 For `localnet`, you also have the option to build in nightly mode (which is experimental and is used for cutting-edge testing). When you compile, use the following command:
 ```bash


### PR DESCRIPTION
Remove paragraphs from archival, RPC, and validator node docs that discussed using `cargo build -p neard --release` as an alternative to `make release`/`make neard`.

This information is no longer accurate or relevant.